### PR TITLE
Convert utf8 string into bytes if specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.build
+/Log-Dispatch-Slack-*

--- a/lib/Log/Dispatch/Slack.pm
+++ b/lib/Log/Dispatch/Slack.pm
@@ -7,6 +7,7 @@ use warnings;
  
 our $VERSION = '0.0004';
 
+use Encode qw(encode_utf8);
 use WebService::Slack::WebApi;
 use Log::Dispatch::Output;
 use Try::Tiny;
@@ -44,6 +45,7 @@ sub _basic_init {
             channel     => { type => SCALAR },
             icon        => { type => SCALAR, optional => 1 },
             username    => { type => SCALAR, optional => 1 },
+            utf8        => { type => BOOLEAN, optional => 1 },
         }
     );
  
@@ -51,6 +53,7 @@ sub _basic_init {
     $self->{token}      = $p{token};
     $self->{username}   = $p{username};
     $self->{icon}       = $p{icon};
+    $self->{utf8}       = $p{utf8};
 }
 
 sub _make_handle {
@@ -66,7 +69,7 @@ sub log_message {
     my %p    = @_;
     
     my %post_params = (
-        text    => $p{message},
+        text    => $self->{utf8} ? encode_utf8($p{message}) : $p{message},
         channel => $p{channel}  || $self->{channel},
     );
     if( $p{icon} ){

--- a/t/002_utf8.t
+++ b/t/002_utf8.t
@@ -1,0 +1,58 @@
+use strict;
+use utf8;
+use warnings;
+use Log::Dispatch::Slack;
+use Test::Mock::Guard;
+use Test::More;
+
+subtest 'Test with utf8 => 1' => sub {
+    my $guard = mock_guard(
+        'WebService::Slack::WebApi::Chat' => {
+            post_message => sub {
+                my ($chat, %args) = @_;
+
+                no utf8;
+                is $args{text}, 'あああ';
+
+                { ok => 1 };
+            },
+        },
+    );
+
+    my $slack = Log::Dispatch::Slack->new(
+        min_level => 'info',
+        channel   => 'foo',
+        token     => '12345',
+        username  => 'bar',
+        icon      => 'buz',
+        utf8      => 1,
+    );
+
+    $slack->log_message(level => 'warn', message => 'あああ');
+};
+
+subtest 'Test without utf8' => sub {
+    my $guard = mock_guard(
+        'WebService::Slack::WebApi::Chat' => {
+            post_message => sub {
+                my ($chat, %args) = @_;
+
+                is $args{text}, 'あああ';
+
+                { ok => 1 };
+            },
+        },
+    );
+
+    my $slack = Log::Dispatch::Slack->new(
+        min_level => 'info',
+        channel   => 'foo',
+        token     => '12345',
+        username  => 'bar',
+        icon      => 'buz',
+    );
+
+    $slack->log_message(level => 'warn', message => 'あああ');
+};
+
+done_testing;


### PR DESCRIPTION
Current implementation fails when a utf8-flagged string is logged as:

```
HTTP::Message content must be bytes at local/lib/perl5/HTTP/Request/Common.pm line 101.
```

and this module should accept "utf8" at `new()` just like [Log::Log4perl::Appender::File does](https://github.com/mschilli/log4perl/blob/master/lib/Log/Log4perl/Appender/File.pm#L29)
