### PR TITLE
Allows this appender to ignore slack failures which would crash the application running it (RT#124436)

### DIFF
--- a/lib/Log/Dispatch/Slack.pm
+++ b/lib/Log/Dispatch/Slack.pm
@@ -4,67 +4,81 @@ package Log::Dispatch::Slack;
 
 use strict;
 use warnings;
- 
-our $VERSION = '0.0004';
 
+our $VERSION = '0.0005';
+
+use Carp;
 use WebService::Slack::WebApi;
 use Log::Dispatch::Output;
 use Try::Tiny;
 use JSON::XS qw/decode_json/;
- 
+
 use base qw( Log::Dispatch::Output );
 
 use Params::Validate qw(validate SCALAR BOOLEAN);
 Params::Validate::validation_options( allow_extra => 1 );
 
 sub APPEND {0}
- 
+
 sub new {
     my $proto = shift;
     my $class = ref $proto || $proto;
- 
+
     my %p = @_;
- 
+
     my $self = bless {}, $class;
- 
+
     $self->_basic_init(%p);
     $self->_make_handle;
- 
+
     return $self;
 }
 
 sub _basic_init {
     my $self = shift;
- 
+
     $self->SUPER::_basic_init(@_);
- 
+
     my %p = validate(
         @_, {
-            token       => { type => SCALAR },
-            channel     => { type => SCALAR },
-            icon        => { type => SCALAR, optional => 1 },
-            username    => { type => SCALAR, optional => 1 },
+            token           => { type => SCALAR },
+            channel         => { type => SCALAR },
+            icon            => { type => SCALAR, optional => 1 },
+            username        => { type => SCALAR, optional => 1 },
+            die_on_error    => { type => BOOLEAN, optional => 1, default => 1 }
         }
     );
- 
-    $self->{channel}    = $p{channel};
-    $self->{token}      = $p{token};
-    $self->{username}   = $p{username};
-    $self->{icon}       = $p{icon};
+
+    $self->{channel}        = $p{channel};
+    $self->{token}          = $p{token};
+    $self->{username}       = $p{username};
+    $self->{icon}           = $p{icon};
+    $self->{die_on_error}   = $p{die_on_error};
+
+    return;
 }
 
 sub _make_handle {
     my $self = shift;
- 
-    $self->{client} = WebService::Slack::WebApi->new(
-        token  => $self->{token},
-    );
+
+    try {
+        $self->{client} = WebService::Slack::WebApi->new(
+            token  => $self->{token},
+        );
+    } catch {
+        my $msg = "Error initialising Webservice::Slack::WebApi: $_";
+        if ($self->{die_on_error}) {
+            croak $msg;
+        }
+        carp $msg;
+    };
+    return;
 }
 
 sub log_message {
     my $self = shift;
     my %p    = @_;
-    
+
     my %post_params = (
         text    => $p{message},
         channel => $p{channel}  || $self->{channel},
@@ -74,7 +88,7 @@ sub log_message {
     }elsif( $self->{icon} ){
         $post_params{icon_url} = $self->{icon};
     }
-    
+
     if( $p{username} ){
         $post_params{username} = $p{username};
     }elsif( $self->{username} ){
@@ -82,15 +96,22 @@ sub log_message {
     }else{
         $post_params{as_user} = 1;
     }
-    
+
     my $response = $self->{client}->chat->post_message( %post_params );
-    
+
     if( ! $response->{ok} ){
-        die( sprintf( "Failed to send message to channel (%s): %s", $self->{channel}, $response->{error} ) );
+
+        my $msg = sprintf( "Failed to send message to channel (%s): %s", $self->{channel}, $response->{error} );
+        if ($self->{die_on_error}) {
+            croak $msg;
+        }
+        carp $msg;
     }
+
+    return;
 }
- 
- 
+
+
 1;
 
 =head1 NAME
@@ -106,6 +127,7 @@ Send log messages to Slack
   log4perl.appender.hipchat=Log::Dispatch::Slack
   log4perl.appender.hipchat.auth_token=your-auth-token
   log4perl.appender.hipchat.channel=channel-to-talk-to
+  log4perl.appender.hipchat.die_on_error=1
 
 =head1 COPYRIGHT
 
@@ -114,4 +136,8 @@ Copyright 2016, Robin Clarke
 =head1 AUTHOR
 
 Robin Clarke <robin@robinclarke.net>
+
+=head1 CONTRIBUTORS
+
+Bartlomiej Fulanty <starlight@cpan.org>
 

--- a/lib/Log/Dispatch/Slack.pm
+++ b/lib/Log/Dispatch/Slack.pm
@@ -129,6 +129,8 @@ Send log messages to Slack
   log4perl.appender.hipchat.channel=channel-to-talk-to
   log4perl.appender.hipchat.die_on_error=1
 
+  log4perl.appender.hipchat.username=set-to-something-if-using-app-token
+
 =head1 COPYRIGHT
 
 Copyright 2016, Robin Clarke
@@ -139,5 +141,5 @@ Robin Clarke <robin@robinclarke.net>
 
 =head1 CONTRIBUTORS
 
-Bartlomiej Fulanty <starlight@cpan.org>
+Bartlomiej Fulanty <starlight@cpan.org>, Hurra.com
 

--- a/t/001_base.t
+++ b/t/001_base.t
@@ -10,6 +10,9 @@ use Test::Exception;
 
 my $DIE_DIE_DIE = 0;
 
+
+use_ok 'Log::Dispatch::Slack';
+
 my $mock = Test::MockModule->new('Log::Dispatch::Slack');
 $mock->mock('_make_handle', sub {
     my $self = shift;
@@ -36,8 +39,6 @@ $mock->mock('_make_handle', sub {
     $self->{client} = $swapi;
     return;
 });
-
-use_ok 'Log::Dispatch::Slack';
 
 my $slack = Log::Dispatch::Slack->new( token => 'aaaa', channel => '#dr-strange', min_level => 1);
 lives_ok {

--- a/t/001_base.t
+++ b/t/001_base.t
@@ -24,7 +24,7 @@ $mock->mock('_make_handle', sub {
             if ($DIE_DIE_DIE) {
                 return {
                     'ok' => 0,
-                    'error' => 255,
+                    'error' => 'some_slack_error',
                 }
             }
 
@@ -48,7 +48,7 @@ $DIE_DIE_DIE = 1;
 
 throws_ok {
     $slack->log_message(message=>"lalala");
-} qr/\QFailed to send message to channel (#dr-strange): 255\E/, "Now it dies as it's supposed to";
+} qr/\QFailed to send message to channel (#dr-strange): some_slack_error\E/, "Now it dies as it is supposed to";
 
 lives_ok {
     my $slack = Log::Dispatch::Slack->new( token => 'aaaa', channel => '#dr-strange', die_on_error => 0, min_level => 1);

--- a/t/001_base.t
+++ b/t/001_base.t
@@ -1,5 +1,59 @@
 use strict;
 use warnings;
 
-use Test::More tests => 1;
+use Test::More;
+
+use Test::MockModule;
+use Test::MockObject;
+
+use Test::Exception;
+
+my $DIE_DIE_DIE = 0;
+
+my $mock = Test::MockModule->new('Log::Dispatch::Slack');
+$mock->mock('_make_handle', sub {
+    my $self = shift;
+
+    # mock Webservice::Slack::WebApi first
+    my $swapi = Test::MockObject->new();
+    $swapi->mock('chat', sub {
+
+        # now mock Webservice::Slack::WebApi::Chat
+        my $chat = Test::MockObject->new();
+        my $post = $chat->mock('post_message', sub {
+            if ($DIE_DIE_DIE) {
+                return {
+                    'ok' => 0,
+                    'error' => 255,
+                }
+            }
+
+            return {
+                ok => 1,
+            }
+        })
+    });
+    $self->{client} = $swapi;
+    return;
+});
+
 use_ok 'Log::Dispatch::Slack';
+
+my $slack = Log::Dispatch::Slack->new( token => 'aaaa', channel => '#dr-strange', min_level => 1);
+lives_ok {
+    $slack->log_message(message=>"lalala");
+} 'Successfully "sent message" via our mockery';
+
+$DIE_DIE_DIE = 1;
+
+throws_ok {
+    $slack->log_message(message=>"lalala");
+} qr/\QFailed to send message to channel (#dr-strange): 255\E/, "Now it dies as it's supposed to";
+
+lives_ok {
+    my $slack = Log::Dispatch::Slack->new( token => 'aaaa', channel => '#dr-strange', die_on_error => 0, min_level => 1);
+    $slack->log_message(message=>"lalala");
+} "And now it lives again!";
+
+done_testing();
+__END__


### PR DESCRIPTION
Hi,

As promised - a PR including die_on_error property. This closes RT#124436.

Added tests for die_on_error property, mocking the Webservice::Slack::WebApi, so they can be run without a working token, or even Slack ;-)

Last but not least keeping code and perl-critic happy - whitespace removed, some 'returns' were added to subs, and croak / carp was used instead of die/warn.